### PR TITLE
fixes npm run build

### DIFF
--- a/Part-1/ionic7-vue-sqlite-app/src/shims-vue.d.ts
+++ b/Part-1/ionic7-vue-sqlite-app/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue'
+    const component: DefineComponent<{}, {}, any>
+    export default component
+  }


### PR DESCRIPTION
Typescript needs this file in order to recognize modules in ".vue" files.

Without this, I was not able to run "npm run build".

More on this here: https://stackoverflow.com/questions/54622621/what-does-the-shims-tsx-d-ts-file-do-in-a-vue-typescript-project/59788563#59788563